### PR TITLE
Expose low-level interface.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ impl<SpiE, GpioE> From<lowlevel::Error<SpiE, GpioE>> for Error<SpiE, GpioE> {
 }
 
 /// High level API for interacting with the CC1101 radio chip.
-pub struct Cc1101<SPI, CS>(lowlevel::Cc1101<SPI, CS>);
+pub struct Cc1101<SPI, CS>(pub lowlevel::Cc1101<SPI, CS>);
 
 impl<SPI, CS, SpiE, GpioE> Cc1101<SPI, CS>
 where


### PR DESCRIPTION
Sometimes a user of the library may want to use the high-level interface for most things, but set some other registers which are not currently supported in the high-level interface. This lets them combine the high-level interface with the low-level interface when necessary.