### PR TITLE
Add a bunch more methods to the high-level interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ where
         Ok(Cc1101(lowlevel::Cc1101::new(spi, cs)?))
     }
 
+    /// Sets the carrier frequency (in Hertz).
     pub fn set_frequency(&mut self, hz: u64) -> Result<(), Error<SpiE, GpioE>> {
         let (freq0, freq1, freq2) = from_frequency(hz);
         self.0.write_register(Config::FREQ0, freq0)?;
@@ -65,6 +66,7 @@ where
         Ok(())
     }
 
+    /// Sets the data rate (in bits per second).
     pub fn set_data_rate(&mut self, baud: u64) -> Result<(), Error<SpiE, GpioE>> {
         let (mantissa, exponent) = from_drate(baud);
         self.0
@@ -73,6 +75,7 @@ where
         Ok(())
     }
 
+    /// Sets the channel bandwidth (in Hertz).
     pub fn set_chanbw(&mut self, bandwidth: u64) -> Result<(), Error<SpiE, GpioE>> {
         let (mantissa, exponent) = from_chanbw(bandwidth);
         self.0.modify_register(Config::MDMCFG4, |r| {
@@ -190,6 +193,12 @@ where
             }
         };
         self.await_machine_state(target)
+    }
+
+    /// Resets the chip.
+    pub fn reset(&mut self) -> Result<(), Error<SpiE, GpioE>> {
+        self.0.write_strobe(Command::SRES)?;
+        Ok(())
     }
 
     /// Configure some default settings, to be removed in the future.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,13 @@ where
         Ok(())
     }
 
+    /// Sets the frequency synthesizer intermediate frequency (in Hertz).
+    pub fn set_synthesizer_if(&mut self, hz: u64) -> Result<(), Error<SpiE, GpioE>> {
+        self.0
+            .write_register(Config::FSCTRL1, FSCTRL1::default().freq_if(from_freq_if(hz)).bits())?;
+        Ok(())
+    }
+
     pub fn set_deviation(&mut self, deviation: u64) -> Result<(), Error<SpiE, GpioE>> {
         let (mantissa, exponent) = from_deviation(deviation);
         self.0.write_register(
@@ -210,9 +217,7 @@ where
             .white_data(0).bits()
         )?;
 
-        self.0.write_register(Config::FSCTRL1, FSCTRL1::default()
-            .freq_if(0x08).bits() // f_if = (f_osc / 2^10) * FREQ_IF
-        )?;
+        self.set_synthesizer_if(203_125)?;
 
         self.0.write_register(Config::MDMCFG2, MDMCFG2::default()
             .dem_dcfilt_off(1).bits()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,6 +314,15 @@ where
             }
         }
     }
+
+    /// Configures raw data to be passed through, without any packet handling.
+    pub fn set_raw_mode(&mut self) -> Result<(), Error<SpiE, GpioE>> {
+        // Serial data output.
+        self.0.write_register(Config::IOCFG0, 0x0d)?;
+        // Disable data whitening and CRC, fixed packet length, asynchronous serial mode.
+        self.0.write_register(Config::PKTCTRL0, 0x30)?;
+        Ok(())
+    }
 }
 
 /// Modulation format configuration.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,17 @@ where
         Ok(())
     }
 
+    /// Sets the filter length (in FSK/MSK mode) or decision boundary (in OOK/ASK mode) for the AGC.
+    pub fn set_agc_filter_length(
+        &mut self,
+        filter_length: FilterLength,
+    ) -> Result<(), Error<SpiE, GpioE>> {
+        self.0.modify_register(Config::AGCCTRL0, |r| {
+            AGCCTRL0(r).modify().filter_length(filter_length.into()).bits()
+        })?;
+        Ok(())
+    }
+
     pub fn set_deviation(&mut self, deviation: u64) -> Result<(), Error<SpiE, GpioE>> {
         let (mantissa, exponent) = from_deviation(deviation);
         self.0.write_register(
@@ -381,6 +392,26 @@ pub enum TargetAmplitude {
 
 impl From<TargetAmplitude> for u8 {
     fn from(value: TargetAmplitude) -> Self {
+        value as Self
+    }
+}
+
+/// Channel filter samples or OOK/ASK decision boundary for AGC.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum FilterLength {
+    /// 8 filter samples for FSK/MSK, or 4 dB for OOK/ASK.
+    Samples8 = 0,
+    /// 16 filter samples for FSK/MSK, or 8 dB for OOK/ASK.
+    Samples16 = 1,
+    /// 32 filter samples for FSK/MSK, or 12 dB for OOK/ASK.
+    Samples32 = 2,
+    /// 64 filter samples for FSK/MSK, or 16 dB for OOK/ASK.
+    Samples64 = 3,
+}
+
+impl From<FilterLength> for u8 {
+    fn from(value: FilterLength) -> Self {
         value as Self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,14 @@ where
         Ok(())
     }
 
+    /// Sets the target value for the averaged amplitude from the digital channel filter.
+    pub fn set_agc_target(&mut self, target: TargetAmplitude) -> Result<(), Error<SpiE, GpioE>> {
+        self.0.modify_register(Config::AGCCTRL2, |r| {
+            AGCCTRL2(r).modify().magn_target(target.into()).bits()
+        })?;
+        Ok(())
+    }
+
     pub fn set_deviation(&mut self, deviation: u64) -> Result<(), Error<SpiE, GpioE>> {
         let (mantissa, exponent) = from_deviation(deviation);
         self.0.write_register(
@@ -347,4 +355,32 @@ pub enum SyncMode {
     MatchPartialRepeated(u16),
     /// Match 16 of 16 bits of given sync word.
     MatchFull(u16),
+}
+
+/// Target amplitude for AGC.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum TargetAmplitude {
+    /// 24 dB
+    Db24 = 0,
+    /// 27 dB
+    Db27 = 1,
+    /// 30 dB
+    Db30 = 2,
+    /// 33 dB
+    Db33 = 3,
+    /// 36 dB
+    Db36 = 4,
+    /// 38 dB
+    Db38 = 5,
+    /// 40 dB
+    Db40 = 6,
+    /// 42 dB
+    Db42 = 7,
+}
+
+impl From<TargetAmplitude> for u8 {
+    fn from(value: TargetAmplitude) -> Self {
+        value as Self
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,17 @@ where
         Ok(())
     }
 
+    /// Configures when to run automatic calibration.
+    pub fn set_autocalibration(
+        &mut self,
+        autocal: AutoCalibration,
+    ) -> Result<(), Error<SpiE, GpioE>> {
+        self.0.modify_register(Config::MCSM0, |r| {
+            MCSM0(r).modify().fs_autocal(autocal.into()).bits()
+        })?;
+        Ok(())
+    }
+
     pub fn set_deviation(&mut self, deviation: u64) -> Result<(), Error<SpiE, GpioE>> {
         let (mantissa, exponent) = from_deviation(deviation);
         self.0.write_register(
@@ -242,9 +253,7 @@ where
             .dem_dcfilt_off(1).bits()
         )?;
 
-        self.0.write_register(Config::MCSM0, MCSM0::default()
-            .fs_autocal(AutoCalibration::FROM_IDLE.value()).bits()
-        )?;
+        self.set_autocalibration(AutoCalibration::FromIdle)?;
 
         self.0.write_register(Config::AGCCTRL2, AGCCTRL2::default()
             .max_lna_gain(0x04).bits()

--- a/src/lowlevel/types/auto_calibration.rs
+++ b/src/lowlevel/types/auto_calibration.rs
@@ -1,19 +1,18 @@
 /// Configure what state transitions result in auto-calibration.
-#[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum AutoCalibration {
     /// Never (manually calibrate using SCAL strobe).
-    DISABLED = 0x00,
+    Disabled = 0x00,
     /// When going from IDLE to RX or TX (or FSTXON).
-    FROM_IDLE = 0x01,
+    FromIdle = 0x01,
     /// When going from RX or TX back to IDLE automatically.
-    TO_IDLE = 0x02,
+    ToIdle = 0x02,
     /// Every 4th time when going from RX or TX to IDLE automatically.
-    TO_IDLE_EVERY_4TH = 0x03,
+    ToIdleEvery4th = 0x03,
 }
 
-impl AutoCalibration {
-    pub fn value(&self) -> u8 {
-        *self as u8
+impl From<AutoCalibration> for u8 {
+    fn from(value: AutoCalibration) -> u8 {
+        value as u8
     }
 }


### PR DESCRIPTION
I'm trying to use this library to decode signals from 433 MHz remote buttons, and these methods expose the functionality I've found necessary so far.