### PR TITLE
Implement Display and Error traits for errors where possible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ edition = "2021"
 
 [dependencies]
 embedded-hal = "0.2.3"
+
+[features]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 
 extern crate embedded_hal as hal;
 
+#[cfg(feature = "std")]
+extern crate std;
+
 use core::fmt::{self, Display, Formatter};
 use hal::blocking::spi::{Transfer, Write};
 use hal::digital::v2::OutputPin;
@@ -46,6 +49,12 @@ impl<SpiE: Display, GpioE: Display> Display for Error<SpiE, GpioE> {
             Self::Gpio(e) => write!(f, "GPIO error: {}", e),
         }
     }
+}
+
+#[cfg(feature = "std")]
+impl<SpiE: Display + core::fmt::Debug, GpioE: Display + core::fmt::Debug> std::error::Error
+    for Error<SpiE, GpioE>
+{
 }
 
 /// High level API for interacting with the CC1101 radio chip.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate embedded_hal as hal;
 
+use core::fmt::{self, Display, Formatter};
 use hal::blocking::spi::{Transfer, Write};
 use hal::digital::v2::OutputPin;
 
@@ -32,6 +33,17 @@ impl<SpiE, GpioE> From<lowlevel::Error<SpiE, GpioE>> for Error<SpiE, GpioE> {
         match e {
             lowlevel::Error::Spi(inner) => Error::Spi(inner),
             lowlevel::Error::Gpio(inner) => Error::Gpio(inner),
+        }
+    }
+}
+
+impl<SpiE: Display, GpioE: Display> Display for Error<SpiE, GpioE> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::RxOverflow => write!(f, "RX FIFO buffer overflowed"),
+            Self::CrcMismatch => write!(f, "CRC mismatch"),
+            Self::Spi(e) => write!(f, "SPI error: {}", e),
+            Self::Gpio(e) => write!(f, "GPIO error: {}", e),
         }
     }
 }

--- a/src/lowlevel.rs
+++ b/src/lowlevel.rs
@@ -1,4 +1,6 @@
 //! Low level unrestricted access to the CC1101 radio chip.
+
+use core::fmt::{self, Display, Formatter};
 use hal::blocking::spi::{Transfer, Write};
 use hal::digital::v2::OutputPin;
 
@@ -26,6 +28,15 @@ pub struct Cc1101<SPI, CS> {
 pub enum Error<SpiE, GpioE> {
     Spi(SpiE),
     Gpio(GpioE),
+}
+
+impl<SpiE: Display, GpioE: Display> Display for Error<SpiE, GpioE> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            Self::Spi(e) => write!(f, "SPI error: {}", e),
+            Self::Gpio(e) => write!(f, "GPIO error: {}", e),
+        }
+    }
 }
 
 impl<SPI, CS, SpiE, GpioE> Cc1101<SPI, CS>

--- a/src/lowlevel.rs
+++ b/src/lowlevel.rs
@@ -39,6 +39,12 @@ impl<SpiE: Display, GpioE: Display> Display for Error<SpiE, GpioE> {
     }
 }
 
+#[cfg(feature = "std")]
+impl<SpiE: Display + core::fmt::Debug, GpioE: Display + core::fmt::Debug> std::error::Error
+    for Error<SpiE, GpioE>
+{
+}
+
 impl<SPI, CS, SpiE, GpioE> Cc1101<SPI, CS>
 where
     SPI: Transfer<u8, Error = SpiE> + Write<u8, Error = SpiE>,


### PR DESCRIPTION
The `Error` trait is in `std`, so is guarded by the new `std` feature. This makes error handling easier for projects which do have `std`, as it allows errors to be used more easily with `anyhow`, `eyre` and similar crates.