### PR TITLE
Update to embedded-hal 1.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/dsvensson/cc1101"
 edition = "2021"
 
 [dependencies]
-embedded-hal = "0.2.3"
+embedded-hal = "1.0.0"
 
 [features]
 std = []

--- a/src/lowlevel.rs
+++ b/src/lowlevel.rs
@@ -1,8 +1,6 @@
 //! Low level unrestricted access to the CC1101 radio chip.
 
-use core::fmt::{self, Display, Formatter};
-use hal::blocking::spi::{Transfer, Write};
-use hal::digital::v2::OutputPin;
+use hal::spi::{Operation, SpiDevice};
 
 #[macro_use]
 mod macros;
@@ -17,70 +15,39 @@ use self::registers::*;
 
 pub const FXOSC: u64 = 26_000_000;
 
-pub struct Cc1101<SPI, CS> {
+pub struct Cc1101<SPI> {
     pub(crate) spi: SPI,
-    pub(crate) cs: CS,
     //    gdo0: GDO0,
     //    gdo2: GDO2,
 }
 
-#[derive(Debug)]
-pub enum Error<SpiE, GpioE> {
-    Spi(SpiE),
-    Gpio(GpioE),
-}
-
-impl<SpiE: Display, GpioE: Display> Display for Error<SpiE, GpioE> {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        match self {
-            Self::Spi(e) => write!(f, "SPI error: {}", e),
-            Self::Gpio(e) => write!(f, "GPIO error: {}", e),
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<SpiE: Display + core::fmt::Debug, GpioE: Display + core::fmt::Debug> std::error::Error
-    for Error<SpiE, GpioE>
-{
-}
-
-impl<SPI, CS, SpiE, GpioE> Cc1101<SPI, CS>
+impl<SPI, SpiE> Cc1101<SPI>
 where
-    SPI: Transfer<u8, Error = SpiE> + Write<u8, Error = SpiE>,
-    CS: OutputPin<Error = GpioE>,
+    SPI: SpiDevice<u8, Error = SpiE>,
 {
-    pub fn new(spi: SPI, cs: CS) -> Result<Self, Error<SpiE, GpioE>> {
+    pub fn new(spi: SPI) -> Result<Self, SpiE> {
         let cc1101 = Cc1101 {
             spi,
-            cs,
         };
         Ok(cc1101)
     }
 
-    pub fn read_register<R>(&mut self, reg: R) -> Result<u8, Error<SpiE, GpioE>>
+    pub fn read_register<R>(&mut self, reg: R) -> Result<u8, SpiE>
     where
         R: Into<Register>,
     {
-        self.cs.set_low().map_err(Error::Gpio)?;
         let mut buffer = [reg.into().raddr(), 0u8];
-        self.spi.transfer(&mut buffer).map_err(Error::Spi)?;
-        self.cs.set_high().map_err(Error::Gpio)?;
+        self.spi.transfer_in_place(&mut buffer)?;
         Ok(buffer[1])
     }
 
-    pub fn read_fifo(
-        &mut self,
-        addr: &mut u8,
-        len: &mut u8,
-        buf: &mut [u8],
-    ) -> Result<(), Error<SpiE, GpioE>> {
+    pub fn read_fifo(&mut self, addr: &mut u8, len: &mut u8, buf: &mut [u8]) -> Result<(), SpiE> {
         let mut buffer = [Command::FIFO.addr() | 0xC0, 0, 0];
 
-        self.cs.set_low().map_err(Error::Gpio)?;
-        self.spi.transfer(&mut buffer).map_err(Error::Spi)?;
-        self.spi.transfer(buf).map_err(Error::Spi)?;
-        self.cs.set_high().map_err(Error::Gpio)?;
+        self.spi.transaction(&mut [
+            Operation::TransferInPlace(&mut buffer),
+            Operation::TransferInPlace(buf),
+        ])?;
 
         *len = buffer[1];
         *addr = buffer[2];
@@ -88,24 +55,20 @@ where
         Ok(())
     }
 
-    pub fn write_strobe(&mut self, com: Command) -> Result<(), Error<SpiE, GpioE>> {
-        self.cs.set_low().map_err(Error::Gpio)?;
-        self.spi.write(&[com.addr()]).map_err(Error::Spi)?;
-        self.cs.set_high().map_err(Error::Gpio)?;
+    pub fn write_strobe(&mut self, com: Command) -> Result<(), SpiE> {
+        self.spi.write(&[com.addr()])?;
         Ok(())
     }
 
-    pub fn write_register<R>(&mut self, reg: R, byte: u8) -> Result<(), Error<SpiE, GpioE>>
+    pub fn write_register<R>(&mut self, reg: R, byte: u8) -> Result<(), SpiE>
     where
         R: Into<Register>,
     {
-        self.cs.set_low().map_err(Error::Gpio)?;
-        self.spi.write(&[reg.into().waddr(), byte]).map_err(Error::Spi)?;
-        self.cs.set_high().map_err(Error::Gpio)?;
+        self.spi.write(&[reg.into().waddr(), byte])?;
         Ok(())
     }
 
-    pub fn modify_register<R, F>(&mut self, reg: R, f: F) -> Result<(), Error<SpiE, GpioE>>
+    pub fn modify_register<R, F>(&mut self, reg: R, f: F) -> Result<(), SpiE>
     where
         R: Into<Register> + Copy,
         F: FnOnce(u8) -> u8,


### PR DESCRIPTION
The new `SpiDevice` trait manages the CS pin, so we no longer need to.