### PR TITLE
Add status byte feature #40

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ where
     }
 
     /// Last Chip Status Byte
-    pub fn get_last_chip_status_byte(&mut self) -> StatusByte {
+    pub fn get_last_chip_status_byte(&mut self) -> Option<StatusByte> {
         self.0.status
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ where
     }
 
     /// Last Chip Status Byte
-    pub fn get_last_chip_status_byte(&mut self) -> Option<StatusByte> {
+    pub fn get_chip_status(&mut self) -> Option<StatusByte> {
         self.0.status
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,11 @@ where
         Ok(Cc1101(lowlevel::Cc1101::new(spi)?))
     }
 
+    /// Last Chip Status Byte
+    pub fn get_last_chip_status_byte(&mut self) -> StatusByte {
+        self.0.status
+    }
+
     /// Sets the carrier frequency (in Hertz).
     pub fn set_frequency(&mut self, hz: u64) -> Result<(), Error<SpiE>> {
         let (freq0, freq1, freq2) = from_frequency(hz);
@@ -218,21 +223,21 @@ where
         let target = match radio_mode {
             RadioMode::Receive => {
                 self.set_radio_mode(RadioMode::Idle)?;
-                self.0.write_strobe(Command::SRX)?;
+                self.0.write_cmd_strobe(Command::SRX)?;
                 MachineState::RX
             }
             RadioMode::Transmit => {
                 self.set_radio_mode(RadioMode::Idle)?;
-                self.0.write_strobe(Command::STX)?;
+                self.0.write_cmd_strobe(Command::STX)?;
                 MachineState::TX
             }
             RadioMode::Idle => {
-                self.0.write_strobe(Command::SIDLE)?;
+                self.0.write_cmd_strobe(Command::SIDLE)?;
                 MachineState::IDLE
             }
             RadioMode::Calibrate => {
                 self.set_radio_mode(RadioMode::Idle)?;
-                self.0.write_strobe(Command::SCAL)?;
+                self.0.write_cmd_strobe(Command::SCAL)?;
                 MachineState::IDLE
             }
         };
@@ -241,14 +246,14 @@ where
 
     /// Resets the chip.
     pub fn reset(&mut self) -> Result<(), Error<SpiE>> {
-        self.0.write_strobe(Command::SRES)?;
+        self.0.write_cmd_strobe(Command::SRES)?;
         Ok(())
     }
 
     /// Configure some default settings, to be removed in the future.
     #[rustfmt::skip]
     pub fn set_defaults(&mut self) -> Result<(), Error<SpiE, >> {
-        self.0.write_strobe(Command::SRES)?;
+        self.0.write_cmd_strobe(Command::SRES)?;
 
         self.0.write_register(Config::PKTCTRL0, PKTCTRL0::default()
             .white_data(0).bits()
@@ -308,7 +313,7 @@ where
                 self.0.read_fifo(addr, &mut length, buf)?;
                 let lqi = self.0.read_register(Status::LQI)?;
                 self.await_machine_state(MachineState::IDLE)?;
-                self.0.write_strobe(Command::SFRX)?;
+                self.0.write_cmd_strobe(Command::SFRX)?;
                 if (lqi >> 7) != 1 {
                     Err(Error::CrcMismatch)
                 } else {
@@ -316,7 +321,7 @@ where
                 }
             }
             Err(err) => {
-                self.0.write_strobe(Command::SFRX)?;
+                self.0.write_cmd_strobe(Command::SFRX)?;
                 Err(err)
             }
         }

--- a/src/lowlevel.rs
+++ b/src/lowlevel.rs
@@ -14,11 +14,13 @@ pub mod types;
 use self::registers::*;
 
 pub const FXOSC: u64 = 26_000_000;
+const BLANK_BYTE: u8 = 0;
 
 pub struct Cc1101<SPI> {
     pub(crate) spi: SPI,
-    //    gdo0: GDO0,
-    //    gdo2: GDO2,
+    pub status: StatusByte,
+    // gdo0: GDO0,
+    // gdo2: GDO2,
 }
 
 impl<SPI, SpiE> Cc1101<SPI>
@@ -28,6 +30,7 @@ where
     pub fn new(spi: SPI) -> Result<Self, SpiE> {
         let cc1101 = Cc1101 {
             spi,
+            status: StatusByte::default(),
         };
         Ok(cc1101)
     }
@@ -36,8 +39,11 @@ where
     where
         R: Into<Register>,
     {
-        let mut buffer = [reg.into().raddr(), 0u8];
+        let mut buffer = [reg.into().raddr(), BLANK_BYTE];
+
         self.spi.transfer_in_place(&mut buffer)?;
+
+        self.status = StatusByte::from(buffer[0]);
         Ok(buffer[1])
     }
 
@@ -52,11 +58,16 @@ where
         *len = buffer[1];
         *addr = buffer[2];
 
+        self.status = StatusByte::from(buffer[0]);
         Ok(())
     }
 
-    pub fn write_strobe(&mut self, com: Command) -> Result<(), SpiE> {
-        self.spi.write(&[com.addr()])?;
+    pub fn write_cmd_strobe(&mut self, cmd: Command) -> Result<(), SpiE> {
+        let mut buffer = [cmd.addr()];
+
+        self.spi.transfer_in_place(&mut buffer)?;
+
+        self.status = StatusByte::from(buffer[0]);
         Ok(())
     }
 
@@ -64,7 +75,11 @@ where
     where
         R: Into<Register>,
     {
-        self.spi.write(&[reg.into().waddr(), byte])?;
+        let mut buffer = [reg.into().waddr(), byte];
+
+        self.spi.transfer_in_place(&mut buffer)?;
+
+        self.status = StatusByte::from(buffer[0]);
         Ok(())
     }
 
@@ -75,6 +90,7 @@ where
     {
         let r = self.read_register(reg)?;
         self.write_register(reg, f(r))?;
+
         Ok(())
     }
 }

--- a/src/lowlevel.rs
+++ b/src/lowlevel.rs
@@ -18,7 +18,7 @@ const BLANK_BYTE: u8 = 0;
 
 pub struct Cc1101<SPI> {
     pub(crate) spi: SPI,
-    pub status: StatusByte,
+    pub status: Option<StatusByte>,
     // gdo0: GDO0,
     // gdo2: GDO2,
 }
@@ -30,7 +30,7 @@ where
     pub fn new(spi: SPI) -> Result<Self, SpiE> {
         let cc1101 = Cc1101 {
             spi,
-            status: StatusByte::default(),
+            status: None,
         };
         Ok(cc1101)
     }
@@ -43,7 +43,7 @@ where
 
         self.spi.transfer_in_place(&mut buffer)?;
 
-        self.status = StatusByte::from(buffer[0]);
+        self.status = Some(StatusByte::from(buffer[0]));
         Ok(buffer[1])
     }
 
@@ -58,7 +58,7 @@ where
         *len = buffer[1];
         *addr = buffer[2];
 
-        self.status = StatusByte::from(buffer[0]);
+        self.status = Some(StatusByte::from(buffer[0]));
         Ok(())
     }
 
@@ -67,7 +67,14 @@ where
 
         self.spi.transfer_in_place(&mut buffer)?;
 
-        self.status = StatusByte::from(buffer[0]);
+        if cmd == Command::SNOP {
+            // SNOP is the only command with no effect and therefore can be used to get access to the chip status byte
+            self.status = Some(StatusByte::from(buffer[0]));
+        } else {
+            // Discard returned chip status byte in `buffer[0]` as most probably, it will reflect the previous state
+            // Set status to `None`, to inform the user about lack of valid state read
+            self.status = None;
+        }
         Ok(())
     }
 
@@ -79,7 +86,7 @@ where
 
         self.spi.transfer_in_place(&mut buffer)?;
 
-        self.status = StatusByte::from(buffer[0]);
+        self.status = Some(StatusByte::from(buffer[0]));
         Ok(())
     }
 

--- a/src/lowlevel/registers.rs
+++ b/src/lowlevel/registers.rs
@@ -1,10 +1,12 @@
 mod command;
 mod config;
 mod status;
+mod status_byte;
 
 pub use self::command::*;
 pub use self::config::*;
 pub use self::status::*;
+pub use self::status_byte::*;
 
 use crate::lowlevel::access;
 

--- a/src/lowlevel/registers/status_byte.rs
+++ b/src/lowlevel/registers/status_byte.rs
@@ -1,0 +1,71 @@
+/// Indicates the current main state machine mode
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum State {
+    /// IDLE state (Also reported for some transitional states instead of SETTLING or CALIBRATE)
+    IDLE = 0b000,
+    /// Receive mode
+    RX = 0b001,
+    /// Transmit mode
+    TX = 0b010,
+    /// Fast TX ready
+    FSTXON = 0b011,
+    /// Frequency synthesizer calibration is running
+    CALIBRATE = 0b100,
+    /// PLL is settling
+    SETTLING = 0b101,
+    /// RX FIFO has overflowed. Read out any useful data, then flush the FIFO with SFRX
+    RXFIFO_OVERFLOW = 0b110,
+    /// TX FIFO has underflowed. Acknowledge with SFTX
+    TXFIFO_UNDERFLOW = 0b111,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::IDLE
+    }
+}
+
+impl From<u8> for State {
+    fn from(value: u8) -> Self {
+        match value {
+            0b000 => State::IDLE,
+            0b001 => State::RX,
+            0b010 => State::TX,
+            0b011 => State::FSTXON,
+            0b100 => State::CALIBRATE,
+            0b101 => State::SETTLING,
+            0b110 => State::RXFIFO_OVERFLOW,
+            0b111 => State::TXFIFO_UNDERFLOW,
+            _ => panic!("Unknown value: {}", value),
+        }
+    }
+}
+
+/// Table 23: Status Byte
+#[derive(Default, Clone, Copy)]
+pub struct StatusByte {
+    pub chip_rdy: bool,
+    pub state: State,
+    pub fifo_bytes_available: u8,
+}
+
+impl From<u8> for StatusByte {
+    fn from(value: u8) -> Self {
+        let status_byte = STATUS_BYTE(value);
+        StatusByte {
+            chip_rdy: !(status_byte.chip_rdyn() != 0),
+            state: State::from(status_byte.state()),
+            fifo_bytes_available: status_byte.fifo_bytes_available(),
+        }
+    }
+}
+
+register!(STATUS_BYTE, 0b1000_0000, u8, {
+    #[doc = "Stays high until power and crystal have stabilized. Should always be low when using the SPI interface."]
+    chip_rdyn @ 7,
+    #[doc = "Indicates the current main state machine mode"]
+    state @ 4..6,
+    #[doc = "The number of bytes available in the RX FIFO or free bytes in the TX FIFO"]
+    fifo_bytes_available @ 0..3,
+});


### PR DESCRIPTION
- Added `status_byte.rs` module in registers
- Added `get_last_chip_status_byte()` API
- Chip Status Byte is read on every SPI transaction

unrelated:
- updated `write_strobe` method name to `write_cmd_strobe`, this way it seems more intuitive