### PR TITLE
Improve registers module #42

### DIFF
--- a/src/lowlevel.rs
+++ b/src/lowlevel.rs
@@ -39,7 +39,7 @@ where
     where
         R: Into<Register>,
     {
-        let mut buffer = [reg.into().raddr(), BLANK_BYTE];
+        let mut buffer = [reg.into().raddr(access::Mode::Single), BLANK_BYTE];
 
         self.spi.transfer_in_place(&mut buffer)?;
 
@@ -48,7 +48,7 @@ where
     }
 
     pub fn read_fifo(&mut self, addr: &mut u8, len: &mut u8, buf: &mut [u8]) -> Result<(), SpiE> {
-        let mut buffer = [Command::FIFO.addr() | 0xC0, 0, 0];
+        let mut buffer = [MultiByte::FIFO.addr(access::Access::Read, access::Mode::Burst), BLANK_BYTE, BLANK_BYTE];
 
         self.spi.transaction(&mut [
             Operation::TransferInPlace(&mut buffer),
@@ -62,8 +62,20 @@ where
         Ok(())
     }
 
+    pub fn access_fifo(&mut self, access: access::Access, data: &mut [u8]) -> Result<(), SpiE> {
+        let mut buffer = [MultiByte::FIFO.addr(access, access::Mode::Burst)];
+
+        self.spi.transaction(&mut [
+            Operation::TransferInPlace(&mut buffer),
+            Operation::TransferInPlace(data),
+        ])?;
+
+        self.status = Some(StatusByte::from(buffer[0]));
+        Ok(())
+    }
+
     pub fn write_cmd_strobe(&mut self, cmd: Command) -> Result<(), SpiE> {
-        let mut buffer = [cmd.addr()];
+        let mut buffer = [cmd.addr(access::Access::Write, access::Mode::Single)];
 
         self.spi.transfer_in_place(&mut buffer)?;
 
@@ -82,7 +94,7 @@ where
     where
         R: Into<Register>,
     {
-        let mut buffer = [reg.into().waddr(), byte];
+        let mut buffer = [reg.into().waddr(access::Mode::Single), byte];
 
         self.spi.transfer_in_place(&mut buffer)?;
 

--- a/src/lowlevel.rs
+++ b/src/lowlevel.rs
@@ -48,7 +48,11 @@ where
     }
 
     pub fn read_fifo(&mut self, addr: &mut u8, len: &mut u8, buf: &mut [u8]) -> Result<(), SpiE> {
-        let mut buffer = [MultiByte::FIFO.addr(access::Access::Read, access::Mode::Burst), BLANK_BYTE, BLANK_BYTE];
+        let mut buffer = [
+            MultiByte::FIFO.addr(access::Access::Read, access::Mode::Burst),
+            BLANK_BYTE,
+            BLANK_BYTE,
+        ];
 
         self.spi.transaction(&mut [
             Operation::TransferInPlace(&mut buffer),

--- a/src/lowlevel/access.rs
+++ b/src/lowlevel/access.rs
@@ -4,8 +4,8 @@ pub enum Mode {
     Burst = 0x40,
 }
 
-impl Mode {
-    pub fn offset(self, addr: u8) -> u8 {
-        (self as u8) | addr
-    }
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Access {
+    Read = 0x80,
+    Write = 0x00,
 }

--- a/src/lowlevel/registers.rs
+++ b/src/lowlevel/registers.rs
@@ -1,10 +1,12 @@
 mod command;
 mod config;
+mod multi_byte;
 mod status;
 mod status_byte;
 
 pub use self::command::*;
 pub use self::config::*;
+pub use self::multi_byte::*;
 pub use self::status::*;
 pub use self::status_byte::*;
 
@@ -14,23 +16,26 @@ use crate::lowlevel::access;
 pub enum Register {
     Command(command::Command),
     Config(config::Config),
+    MultiByte(multi_byte::MultiByte),
     Status(status::Status),
 }
 
 impl Register {
-    pub fn raddr(self) -> u8 {
-        0x80 | match self {
-            Register::Command(r) => access::Mode::Single.offset(r.addr()),
-            Register::Config(r) => access::Mode::Single.offset(r.addr()),
-            Register::Status(r) => access::Mode::Burst.offset(r.addr()),
+    pub fn raddr(self, mode: access::Mode) -> u8 {
+        match self {
+            Register::Command(r) => r.addr(access::Access::Read, access::Mode::Single),
+            Register::Config(r) => r.addr(access::Access::Read, mode),
+            Register::MultiByte(r) => r.addr(access::Access::Read, mode),
+            Register::Status(r) => r.addr(access::Access::Read, access::Mode::Burst),
         }
     }
 
-    pub fn waddr(self) -> u8 {
+    pub fn waddr(self, mode: access::Mode) -> u8 {
         match self {
-            Register::Command(r) => access::Mode::Single.offset(r.addr()),
-            Register::Config(r) => access::Mode::Single.offset(r.addr()),
-            Register::Status(r) => access::Mode::Burst.offset(r.addr()),
+            Register::Command(r) => r.addr(access::Access::Write, access::Mode::Single),
+            Register::Config(r) => r.addr(access::Access::Write, mode),
+            Register::MultiByte(r) => r.addr(access::Access::Write, mode),
+            Register::Status(_r) => panic!("Status cannot be written!"),
         }
     }
 }

--- a/src/lowlevel/registers/command.rs
+++ b/src/lowlevel/registers/command.rs
@@ -1,48 +1,45 @@
-#[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Command {
-    /// Reset chip
+    /// Reset chip.
     SRES = 0x30,
-    /// Enable/calibrate freq synthesizer
+    /// Enable and calibrate frequency synthesizer (if MCSM0.FS_AUTOCAL=1). If in RX (with CCA): Go to a wait state where only the synthesizer is running (for quick RX / TX turnaround).
     SFSTXON = 0x31,
     /// Turn off crystal oscillator.
     SXOFF = 0x32,
-    /// Calibrate freq synthesizer & disable
+    /// Calibrate frequency synthesizer and turn it off. SCAL can be strobed from IDLE mode without setting manual calibration mode (MCSM0.FS_AUTOCAL=0)
     SCAL = 0x33,
-    /// Enable RX.
+    /// Enable RX. Perform calibration first if coming from IDLE and MCSM0.FS_AUTOCAL=1.
     SRX = 0x34,
-    /// Enable TX.
+    /// In IDLE state: Enable TX. Perform calibration first if MCSM0.FS_AUTOCAL=1. If in RX state and CCA is enabled: Only go to TX if channel is clear.
     STX = 0x35,
-    /// Exit RX / TX
+    /// Exit RX / TX, turn off frequency synthesizer and exit Wake-On-Radio mode if applicable.
     SIDLE = 0x36,
-    /// AFC adjustment of freq synthesizer
-    SAFC = 0x37,
-    /// Start automatic RX polling sequence
+    /// Start automatic RX polling sequence (Wake-on-Radio) as described in Section 19.5 if WORCTRL.RC_PD=0.
     SWOR = 0x38,
-    /// Enter pwr down mode when CSn goes hi
+    /// Enter power down mode when CSn goes high.
     SPWD = 0x39,
-    /// Flush the RX FIFO buffer.
+    /// Flush the RX FIFO buffer. Only issue SFRX in IDLE or RXFIFO_OVERFLOW states.
     SFRX = 0x3A,
-    /// Flush the TX FIFO buffer.
+    /// Flush the TX FIFO buffer. Only issue SFTX in IDLE or TXFIFO_UNDERFLOW states.
     SFTX = 0x3B,
-    /// Reset real time clock.
+    /// Reset real time clock to Event1 value.
     SWORRST = 0x3C,
-    /// No operation.
+    /// No operation. May be used to get access to the chip status byte.
     SNOP = 0x3D,
-    /// Power Amplifier Table
-    PATABLE = 0x3E,
-    /// FIFO Access
-    FIFO = 0x3F,
 }
 
 impl Command {
-    pub fn addr(&self) -> u8 {
-        *self as u8
+    pub fn addr(
+        &self,
+        access: crate::lowlevel::access::Access,
+        mode: crate::lowlevel::access::Mode,
+    ) -> u8 {
+        (access as u8) | (mode as u8) | (*self as u8)
     }
 }
 
 impl From<Command> for crate::lowlevel::registers::Register {
-    fn from(val: Command) -> Self {
-        crate::lowlevel::registers::Register::Command(val)
+    fn from(value: Command) -> Self {
+        crate::lowlevel::registers::Register::Command(value)
     }
 }

--- a/src/lowlevel/registers/config.rs
+++ b/src/lowlevel/registers/config.rs
@@ -97,14 +97,18 @@ pub enum Config {
 }
 
 impl Config {
-    pub fn addr(&self) -> u8 {
-        *self as u8
+    pub fn addr(
+        &self,
+        access: crate::lowlevel::access::Access,
+        mode: crate::lowlevel::access::Mode,
+    ) -> u8 {
+        (access as u8) | (mode as u8) | (*self as u8)
     }
 }
 
 impl From<Config> for crate::lowlevel::registers::Register {
-    fn from(val: Config) -> Self {
-        crate::lowlevel::registers::Register::Config(val)
+    fn from(value: Config) -> Self {
+        crate::lowlevel::registers::Register::Config(value)
     }
 }
 

--- a/src/lowlevel/registers/multi_byte.rs
+++ b/src/lowlevel/registers/multi_byte.rs
@@ -1,0 +1,23 @@
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum MultiByte {
+    /// Power Amplifier Table
+    PATABLE = 0x3E,
+    /// FIFO Access
+    FIFO = 0x3F,
+}
+
+impl MultiByte {
+    pub fn addr(
+        &self,
+        access: crate::lowlevel::access::Access,
+        mode: crate::lowlevel::access::Mode,
+    ) -> u8 {
+        (access as u8) | (mode as u8) | (*self as u8)
+    }
+}
+
+impl From<MultiByte> for crate::lowlevel::registers::Register {
+    fn from(value: MultiByte) -> Self {
+        crate::lowlevel::registers::Register::MultiByte(value)
+    }
+}

--- a/src/lowlevel/registers/status.rs
+++ b/src/lowlevel/registers/status.rs
@@ -32,14 +32,18 @@ pub enum Status {
 }
 
 impl Status {
-    pub fn addr(&self) -> u8 {
-        *self as u8
+    pub fn addr(
+        &self,
+        access: crate::lowlevel::access::Access,
+        mode: crate::lowlevel::access::Mode,
+    ) -> u8 {
+        (access as u8) | (mode as u8) | (*self as u8)
     }
 }
 
 impl From<Status> for crate::lowlevel::registers::Register {
-    fn from(val: Status) -> Self {
-        crate::lowlevel::registers::Register::Status(val)
+    fn from(value: Status) -> Self {
+        crate::lowlevel::registers::Register::Status(value)
     }
 }
 
@@ -54,7 +58,7 @@ register!(VERSION, 0b0001_0100, u8, {
 });
 
 register!(FREQEST, 0b0000_0000, u8, {
-    #[doc = "The estimated frequency offset (2’s complement) of the carrier"]
+    #[doc = "The estimated frequency offset (2's complement) of the carrier"]
     freqoff_est @ 0..7,
 });
 

--- a/src/lowlevel/registers/status_byte.rs
+++ b/src/lowlevel/registers/status_byte.rs
@@ -1,8 +1,9 @@
 /// Indicates the current main state machine mode
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
 pub enum State {
     /// IDLE state (Also reported for some transitional states instead of SETTLING or CALIBRATE)
+    #[default]
     IDLE = 0b000,
     /// Receive mode
     RX = 0b001,
@@ -18,12 +19,6 @@ pub enum State {
     RXFIFO_OVERFLOW = 0b110,
     /// TX FIFO has underflowed. Acknowledge with SFTX
     TXFIFO_UNDERFLOW = 0b111,
-}
-
-impl Default for State {
-    fn default() -> Self {
-        State::IDLE
-    }
 }
 
 impl From<u8> for State {
@@ -54,7 +49,7 @@ impl From<u8> for StatusByte {
     fn from(value: u8) -> Self {
         let status_byte = STATUS_BYTE(value);
         StatusByte {
-            chip_rdy: !(status_byte.chip_rdyn() != 0),
+            chip_rdy: (status_byte.chip_rdyn() == 0),
             state: State::from(status_byte.state()),
             fifo_bytes_available: status_byte.fifo_bytes_available(),
         }


### PR DESCRIPTION
- Added multi_byte module in registers
- Improved all `addr` methods
- Improved `raddr` and `waddr` methods
- Resolved some clippy issues
- Added `access_fifo` method for lowlevel
- Comments for `Command` enum taken from datasheet table

This PR solves issue #42 