### PR TITLE
Added command_strobe function

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -60,36 +60,6 @@ pub enum SyncMode {
     MatchFull(u16),
 }
 
-/// Command Strobes.
-pub enum CommandStrobe {
-    /// SRES
-    ResetChip,
-    /// SFSTXON
-    EnableAndCalFreqSynth,
-    /// SXOFF
-    TurnOffXosc,
-    /// SCAL
-    CalFreqSynthAndTurnOff,
-    /// SRX
-    EnableRx,
-    /// STX
-    EnableTx,
-    /// SIDLE
-    ExitRxTx,
-    /// SWOR
-    StartWakeOnRadio,
-    /// SPWD
-    EnterPowerDownMode,
-    /// SFRX
-    FlushRxFifoBuffer,
-    /// SFTX
-    FlushTxFifoBuffer,
-    /// SWORRST
-    ResetRtcToEvent1,
-    /// SNOP
-    NoOperation,
-}
-
 /// Target amplitude from channel filter.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -60,7 +60,37 @@ pub enum SyncMode {
     MatchFull(u16),
 }
 
-/// Target amplitude for AGC.
+/// Command Strobes.
+pub enum CommandStrobe {
+    /// SRES
+    ResetChip,
+    /// SFSTXON
+    EnableAndCalFreqSynth,
+    /// SXOFF
+    TurnOffXosc,
+    /// SCAL
+    CalFreqSynthAndTurnOff,
+    /// SRX
+    EnableRx,
+    /// STX
+    EnableTx,
+    /// SIDLE
+    ExitRxTx,
+    /// SWOR
+    StartWakeOnRadio,
+    /// SPWD
+    EnterPowerDownMode,
+    /// SFRX
+    FlushRxFifoBuffer,
+    /// SFTX
+    FlushTxFifoBuffer,
+    /// SWORRST
+    ResetRtcToEvent1,
+    /// SNOP
+    NoOperation,
+}
+
+/// Target amplitude from channel filter.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum TargetAmplitude {


### PR DESCRIPTION
- Added dedicated public enum for Command Strobes
- Function `set_synthesizer_if()` renamed to `set_freq_if()`
- Function `set_agc_target()` renamed to `set_magn_target()`
- Function `set_agc_filter_length()` renamed to `set_filter_length()`
- Function `reset()` replaced with `command_strobe(CommandStrobe::ResetChip)`