### PR TITLE
Fixed registers fields range

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,24 @@ where
         Ok(())
     }
 
+    /// Enable automatic flush of RX FIFO when CRC is not OK.
+    /// This requires that only one packet is in the RX FIFO and that packet length is limited to the RX FIFO size.
+    pub fn crc_autoflush_enable(&mut self, enable: bool) -> Result<(), Error<SpiE>> {
+        self.0.modify_register(Config::PKTCTRL1, |r| {
+            PKTCTRL1(r).modify().crc_autoflush(enable as u8).bits()
+        })?;
+        Ok(())
+    }
+
+    /// When enabled, two status bytes will be appended to the payload of the packet.
+    /// The status bytes contain RSSI and LQI values, as well as CRC OK.
+    pub fn append_status_enable(&mut self, enable: bool) -> Result<(), Error<SpiE>> {
+        self.0.modify_register(Config::PKTCTRL1, |r| {
+            PKTCTRL1(r).modify().append_status(enable as u8).bits()
+        })?;
+        Ok(())
+    }
+
     /// Configure device address, and address filtering.
     pub fn set_address_filter(&mut self, filter: AddressFilter) -> Result<(), Error<SpiE>> {
         self.0.address_field = true;

--- a/src/lowlevel/macros.rs
+++ b/src/lowlevel/macros.rs
@@ -16,11 +16,11 @@ macro_rules! register {
 
             $(
                 pub fn $bitfield(&self) -> $uxx {
-                    use crate::lowlevel::traits::OffsetSize;
+                    use crate::lowlevel::traits::{OffsetSize, ToWider};
 
-                    let size = $range.size() + 1;
                     let offset = $range.offset();
-                    (((1 << size) - 1) as u8) << offset
+                    let size = $range.size();
+                    (((1 << size.to_wider()) - 1)) << offset
                 }
             )+
         }
@@ -44,11 +44,11 @@ macro_rules! register {
             $(
                 #[$($attr)*]
                 pub fn $bitfield(&self) -> $uxx {
-                    use crate::lowlevel::traits::OffsetSize;
+                    use crate::lowlevel::traits::{OffsetSize, ToWider};
 
                     let offset = $range.offset();
-                    let size = $range.size() + 1;
-                    let mask = ((1 << size) - 1) as u8;
+                    let size = $range.size();
+                    let mask = ((1 << size.to_wider()) - 1) as $uxx;
 
                     (self.bits >> offset) & mask
                 }
@@ -63,11 +63,11 @@ macro_rules! register {
             $(
                 #[$($attr)*]
                 pub fn $bitfield(&mut self, mut bits: $uxx) -> &mut Self {
-                    use crate::lowlevel::traits::OffsetSize;
+                    use crate::lowlevel::traits::{OffsetSize, ToWider};
 
                     let offset = $range.offset();
-                    let size = $range.size() + 1;
-                    let mask = ((1 << size) - 1) as u8;
+                    let size = $range.size();
+                    let mask = ((1 << size.to_wider()) - 1) as $uxx;
 
                     debug_assert!(bits <= mask);
                     bits &= mask;
@@ -79,5 +79,117 @@ macro_rules! register {
                 }
             )+
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    fn bit_mask(bits: u8) -> u8 {
+        (1 << bits) - 1
+    }
+
+    register!(REG_1, 0b0000_0000, u8, {
+        #[doc = "Bit 7 (1 bit) - 0bx000_0000"]
+        field_7 @ 7,
+        #[doc = "Bit 6 (1 bit) - 0b0x00_0000"]
+        field_6 @ 6,
+        #[doc = "Bit 5 (1 bit) - 0b00x0_0000"]
+        field_5 @ 5,
+        #[doc = "Bit 4 (1 bit) - 0b000x_0000"]
+        field_4 @ 4,
+        #[doc = "Bit 3 (1 bit) - 0b0000_x000"]
+        field_3 @ 3,
+        #[doc = "Bit 2 (1 bit) - 0b0000_0x00"]
+        field_2 @ 2,
+        #[doc = "Bit 1 (1 bit) - 0b0000_00x0"]
+        field_1 @ 1,
+        #[doc = "Bit 0 (1 bit) - 0b0000_000x"]
+        field_0 @ 0,
+    });
+
+    register!(REG_2, 0b0000_0000, u8, {
+        #[doc = "Bit 1..8 (7 bits) - 0bxxxx_xxx0"]
+        field_1 @ 1..8,
+        #[doc = "Bit 0 (1 bit) - 0b0000_000x"]
+        field_0 @ 0,
+    });
+
+    register!(REG_3, 0b0000_0000, u8, {
+        #[doc = "Bit 6..7 (2 bits) - 0bxx00_0000"]
+        field_1 @ 6..8,
+        #[doc = "Bit 0..6 (6 bits) - 0b00xx_xxxx"]
+        field_0 @ 0..6,
+    });
+
+    register!(REG_4, 0b0000_0000, u8, {
+        #[doc = "Bit 5..8 (3 bits) - 0bxxx0_0000"]
+        field_1 @ 5..8 ,
+        #[doc = "Bit 0..5 (5 bits) - 0b000x_xxxx"]
+        field_0 @ 0..5,
+    });
+
+    register!(REG_5, 0b0000_0000, u8, {
+        #[doc = "Bit 4..8 (4 bits) - 0bxxxx_0000"]
+        field_1 @ 4..8,
+        #[doc = "Bit 0..4 (4 bits) - 0b0000_xxxx"]
+        field_0 @ 0..4,
+    });
+
+    #[test]
+    fn test_reg_read() {
+        // REG 1
+        assert_eq!(REG_1(u8::MAX).field_0(), bit_mask(1));
+        assert_eq!(REG_1(u8::MAX).field_1(), bit_mask(1));
+        assert_eq!(REG_1(u8::MAX).field_2(), bit_mask(1));
+        assert_eq!(REG_1(u8::MAX).field_3(), bit_mask(1));
+        assert_eq!(REG_1(u8::MAX).field_4(), bit_mask(1));
+        assert_eq!(REG_1(u8::MAX).field_5(), bit_mask(1));
+        assert_eq!(REG_1(u8::MAX).field_6(), bit_mask(1));
+        assert_eq!(REG_1(u8::MAX).field_7(), bit_mask(1));
+
+        // REG 2
+        assert_eq!(REG_2(u8::MAX).field_0(), bit_mask(1));
+        assert_eq!(REG_2(u8::MAX).field_1(), bit_mask(7));
+
+        // REG 3
+        assert_eq!(REG_3(u8::MAX).field_0(), bit_mask(6));
+        assert_eq!(REG_3(u8::MAX).field_1(), bit_mask(2));
+
+        // REG 4
+        assert_eq!(REG_4(u8::MAX).field_0(), bit_mask(5));
+        assert_eq!(REG_4(u8::MAX).field_1(), bit_mask(3));
+
+        // REG 5
+        assert_eq!(REG_5(u8::MAX).field_0(), bit_mask(4));
+        assert_eq!(REG_5(u8::MAX).field_1(), bit_mask(4));
+    }
+    #[test]
+    fn test_reg_write() {
+        // REG 1
+        assert_eq!(REG_1::default().field_0(1).bits(), 0b0000_0001);
+        assert_eq!(REG_1::default().field_1(1).bits(), 0b0000_0010);
+        assert_eq!(REG_1::default().field_2(1).bits(), 0b0000_0100);
+        assert_eq!(REG_1::default().field_3(1).bits(), 0b0000_1000);
+        assert_eq!(REG_1::default().field_4(1).bits(), 0b0001_0000);
+        assert_eq!(REG_1::default().field_5(1).bits(), 0b0010_0000);
+        assert_eq!(REG_1::default().field_6(1).bits(), 0b0100_0000);
+        assert_eq!(REG_1::default().field_7(1).bits(), 0b1000_0000);
+
+        // REG 2
+        assert_eq!(REG_2::default().field_0(bit_mask(1)).bits(), 0b0000_0001);
+        assert_eq!(REG_2::default().field_1(bit_mask(7)).bits(), 0b1111_1110);
+
+        // REG 3
+        assert_eq!(REG_3::default().field_0(bit_mask(6)).bits(), 0b0011_1111);
+        assert_eq!(REG_3::default().field_1(bit_mask(2)).bits(), 0b1100_0000);
+
+        // REG 4
+        assert_eq!(REG_4::default().field_0(bit_mask(5)).bits(), 0b0001_1111);
+        assert_eq!(REG_4::default().field_1(bit_mask(3)).bits(), 0b1110_0000);
+
+        // REG 5
+        assert_eq!(REG_5::default().field_0(bit_mask(4)).bits(), 0b0000_1111);
+        assert_eq!(REG_5::default().field_1(bit_mask(4)).bits(), 0b1111_0000);
     }
 }

--- a/src/lowlevel/registers/config.rs
+++ b/src/lowlevel/registers/config.rs
@@ -116,7 +116,7 @@ register!(IOCFG2, 0b0010_1001, u8, {
     #[doc = "Invert output, i.e. select active low (1) / high (0)"]
     gdo2_inv @ 6,
     #[doc = "Default is CHP_RDYn (See Table 41 on page 62)"]
-    gdo2_cfg @ 0..5,
+    gdo2_cfg @ 0..6,
 });
 
 register!(IOCFG1, 0b0010_1110, u8, {
@@ -125,7 +125,7 @@ register!(IOCFG1, 0b0010_1110, u8, {
     #[doc = "Invert output, i.e. select active low (1) / high (0)"]
     gdo1_inv @ 6,
     #[doc = "Default is 3-state (See Table 41 on page 62)"]
-    gdo1_cfg @ 0..5,
+    gdo1_cfg @ 0..6,
 });
 
 register!(IOCFG0, 0b0011_1111, u8, {
@@ -134,134 +134,134 @@ register!(IOCFG0, 0b0011_1111, u8, {
     #[doc = "Invert output, i.e. select active low (1) / high (0)"]
     gdo0_inv @ 6,
     #[doc = "Default is CLK_XOSC/192 (See Table 41 on page 62)."]
-    gdo0_cfg @ 0..5,
+    gdo0_cfg @ 0..6,
 });
 
 register!(FIFOTHR, 0b0000_0111, u8, {
     #[doc = "Analog to Digital Converter retention"]
     adc_retention @ 6,
     #[doc = "RX Attenuation, see DN010 for more details"]
-    close_in_rx @ 4..5,
+    close_in_rx @ 4..6,
     #[doc = "Set the threshold for the TX FIFO and RX FIFO"]
-    fifo_thr @ 0..3,
+    fifo_thr @ 0..4,
 });
 
 register!(SYNC1, 0b1101_0011, u8, {
     #[doc = "8 MSB of 16-bit sync word"]
-    sync @ 0..7,
+    sync @ 0..8,
 });
 
 register!(SYNC0, 0b1001_0001, u8, {
     #[doc = "8 LSB of 16-bit sync word"]
-    sync @ 0..7,
+    sync @ 0..8,
 });
 
 register!(PKTLEN, 0b1111_1111, u8, {
     #[doc = "Packet length if mode is fixed, or max length if variable"]
-    packet_length @ 0..7,
+    packet_length @ 0..8,
 });
 
 register!(PKTCTRL1, 0b0000_0100, u8, {
     #[doc = "Preamble quality estimator threshold."]
-    pqt @ 5..7,
+    pqt @ 5..8,
     #[doc = "Enable automatic flush of RX FIFO when CRC is not OK."]
     crc_autoflush @ 3,
     #[doc = "Append RSSI and LQI to RX payload"]
     append_status @ 2,
     #[doc = "Address check configuration of received packages"]
-    adr_chk @ 0..1,
+    adr_chk @ 0..2,
 });
 
 register!(PKTCTRL0, 0b0100_0101, u8, {
     #[doc = "Turn data whitening on / off"]
     white_data @ 6,
     #[doc = "Format of RX and TX data"]
-    pkt_format @ 4..5,
+    pkt_format @ 4..6,
     #[doc = "CRC calculation on / off"]
     crc_en @ 2,
     #[doc = "Packet length configuration"]
-    length_config @ 0..1,
+    length_config @ 0..2,
 });
 
 register!(ADDR, 0b0000_0000, u8, {
     #[doc = "Address used for packet filtration"]
-    device_addr @ 0..7,
+    device_addr @ 0..8,
 });
 
 register!(CHANNR, 0b0000_0000, u8, {
     #[doc = "Channel number, which is multiplied by the channel spacing setting and added to the base frequency."]
-    chan @ 0..7,
+    chan @ 0..8,
 });
 
 register!(FSCTRL1, 0b0000_1111, u8, {
     #[doc = "The desired IF frequency to employ in RX"]
-    freq_if @ 0..4,
+    freq_if @ 0..5,
 });
 
 register!(FSCTRL0, 0b0000_0000, u8, {
     #[doc = "Frequency offset added to the base frequency before being used by the frequency synthesizer. (2-comp)"]
-    freqoff @ 0..7,
+    freqoff @ 0..8,
 });
 
 register!(FREQ2, 0b0001_1110, u8, {
-    #[doc = "FREQ\\[23:0\\] is the base frequency for the frequency synthesiser"]
-    freq @ 0..5,
+    #[doc = "FREQ\\[21:16\\] is the base frequency for the frequency synthesiser"]
+    freq @ 0..6,
 });
 
 register!(FREQ1, 0b1100_0100, u8, {
     #[doc = "FREQ\\[15:8\\], see FREQ2"]
-    freq @ 0..7,
+    freq @ 0..8,
 });
 
 register!(FREQ0, 0b1110_1100, u8, {
     #[doc = "FREQ\\[7:0\\], see FREQ2"]
-    freq @ 0..7,
+    freq @ 0..8,
 });
 
 register!(MDMCFG4, 0b1000_1100, u8, {
     #[doc = "Exponent of channel bandwidth"]
-    chanbw_e @ 6..7,
+    chanbw_e @ 6..8,
     #[doc = "Mantissa of channel bandwidth"]
-    chanbw_m @ 4..5,
+    chanbw_m @ 4..6,
     #[doc = "Exponent of symbol rate"]
-    drate_e @ 0..3,
+    drate_e @ 0..4,
 });
 
 register!(MDMCFG3, 0b0010_0010, u8, {
     #[doc = "Mantissa of symbol rate"]
-    drate_m @ 0..7,
+    drate_m @ 0..8,
 });
 
 register!(MDMCFG2, 0b0000_0010, u8, {
     #[doc = "Disable digital DC blocking filter before demodulator"]
     dem_dcfilt_off @ 7,
     #[doc = "The modulation format of the radio signal"]
-    mod_format @ 4..6,
+    mod_format @ 4..7,
     #[doc = "Enables Manchester encoding/decoding"]
     manchester_en @ 3,
     #[doc = "Combined sync-word qualifier mode"]
-    sync_mode @ 0..2,
+    sync_mode @ 0..3,
 });
 
 register!(MDMCFG1, 0b0010_0010, u8, {
     #[doc = "Enable Forward Error Correction"]
     fec_en @ 7,
     #[doc = "Sets the minimum number of preamble bytes to be transmitted"]
-    num_preamble @ 4..6,
+    num_preamble @ 4..7,
     #[doc = "Exponent of channel spacing"]
-    chanspc_e @ 0..1,
+    chanspc_e @ 0..2,
 });
 
 register!(MDMCFG0, 0b1111_1000, u8, {
     #[doc = "Mantissa of channel spacing"]
-    chanspc_m @ 0..7,
+    chanspc_m @ 0..8,
 });
 
 register!(DEVIATN, 0b0100_0111, u8, {
     #[doc = "Exponent of deviation"]
-    deviation_e @ 4..6,
+    deviation_e @ 4..7,
     #[doc = "Mantissa of deviation"]
-    deviation_m @ 0..2,
+    deviation_m @ 0..3,
 });
 
 register!(MCSM2, 0b0000_0111, u8, {
@@ -270,24 +270,24 @@ register!(MCSM2, 0b0000_0111, u8, {
     #[doc = "When RX_TIME expires, check sync_word (0), or either sync_word/PQI (1)"]
     rx_time_qual @ 3,
     #[doc = "Timeout for sync word search in RX for both WOR mode and normal RX operation."]
-    rx_time @ 0..2,
+    rx_time @ 0..3,
 
 });
 
 register!(MCSM1, 0b0011_0000, u8, {
     #[doc = "Selects CCA_MODE; Reflected in CCA signal"]
-    cca_mode @ 4..5,
+    cca_mode @ 4..6,
     #[doc = "Select what should happen when a packet has been received"]
-    rxoff_mode @ 2..3,
+    rxoff_mode @ 2..4,
     #[doc = "Select what should happen when a packet has been sent"]
-    txoff_mode @ 0..1,
+    txoff_mode @ 0..2,
 });
 
 register!(MCSM0, 0b0000_0100, u8, {
     #[doc = "Automatically calibrate when going to RX or TX, or back to IDLE"]
-    fs_autocal @ 4..5,
+    fs_autocal @ 4..6,
     #[doc = "Programs the number of times the six-bit ripple counter must expire after XOSC has stabilized before CHP_RDYn goes low"]
-    po_timeout @ 2..3,
+    po_timeout @ 2..4,
     #[doc = "Enables the pin radio control option"]
     pin_ctrl_en @ 1,
     #[doc = "Force the XOSC to stay on in the SLEEP state"]
@@ -298,159 +298,159 @@ register!(FOCCFG, 0b0011_0110, u8, {
     #[doc = "If set, the demodulator freezes the frequency offset compensation and clock recovery feedback loops until the CS signal goes high"]
     foc_bs_cs_gate @ 5,
     #[doc = "The frequency compensation loop gain to be used before a sync word is detected"]
-    foc_pre_k @ 3..4,
+    foc_pre_k @ 3..5,
     #[doc = "The frequency compensation loop gain to be used after a sync word is detected"]
     foc_post_k @ 2,
     #[doc = "The saturation point for the frequency offset compensation algorithm"]
-    foc_limit @ 0..1,
+    foc_limit @ 0..2,
 });
 
 register!(BSCFG, 0b0110_1100, u8, {
     #[doc = "The clock recovery feedback loop integral gain to be used before a sync word is detected"]
-    bs_pre_ki @ 6..7,
+    bs_pre_ki @ 6..8,
     #[doc = "The clock recovery feedback loop proportional gain to be used before a sync word is detected"]
-    bs_pre_kp @ 4..5,
+    bs_pre_kp @ 4..6,
     #[doc = "The clock recovery feedback loop integral gain to be used after a sync word is detected"]
     bs_post_ki @ 3,
     #[doc = "The clock recovery feedback loop proportional gain to be used after a sync word is detected"]
     bs_post_kp @ 2,
     #[doc = "The saturation point for the data rate offset compensation algorithm"]
-    bs_limit @ 0..1,
+    bs_limit @ 0..2,
 });
 
 register!(AGCCTRL2, 0b0000_0011, u8, {
     #[doc = "Reduces the maximum allowable DVGA gain"]
-    max_dvga_gain @ 6..7,
+    max_dvga_gain @ 6..8,
     #[doc = "Sets the maximum allowable LNA + LNA 2 gain relative to the maximum possible gain"]
-    max_lna_gain @ 3..5,
+    max_lna_gain @ 3..6,
     #[doc = "These bits set the target value for the averaged amplitude from the digital channel filter"]
-    magn_target @ 0..2,
+    magn_target @ 0..3,
 });
 
 register!(AGCCTRL1, 0b0100_0000, u8, {
     #[doc = "Selects between two different strategies for LNA and LNA 2 gain adjustment"]
     agc_lna_priority @ 6,
     #[doc = "Sets the relative change threshold for asserting carrier sense"]
-    carrier_sense_rel_thr @ 4..5,
+    carrier_sense_rel_thr @ 4..6,
     #[doc = "Sets the absolute RSSI threshold for asserting carrier sense."]
-    carrier_sense_abs_thr @ 0..3,
+    carrier_sense_abs_thr @ 0..4,
 });
 
 register!(AGCCTRL0, 0b1001_0001, u8, {
     #[doc = "Sets the level of hysteresis on the magnitude deviation"]
-    hyst_level @ 6..7,
+    hyst_level @ 6..8,
     #[doc = "Sets the number of channel filter samples from a gain adjustment has been made until the AGC algorithm starts accumulating new samples"]
-    wait_time @ 4..5,
+    wait_time @ 4..6,
     #[doc = "Control when the AGC gain should be frozen"]
-    agc_freeze @ 2..3,
+    agc_freeze @ 2..4,
     #[doc = "Filter length, in relation to MOD_FORMAT"]
-    filter_length @ 0..1,
+    filter_length @ 0..2,
 });
 
 register!(WOREVT1, 0b1000_0111, u8, {
     #[doc = "High byte of EVENT0 timeout register"]
-    event @ 0..7,
+    event @ 0..8,
 });
 
 register!(WOREVT0, 0b0110_1011, u8, {
     #[doc = "Low byte of EVENT0 timeout register"]
-    event @ 0..7,
+    event @ 0..8,
 });
 
 register!(WORCTRL, 0b1111_1000, u8, {
     #[doc = "Power down signal to RC oscillator"]
     rc_pd @ 7,
     #[doc = "Timeout setting from register block"]
-    event @ 4..6,
+    event @ 4..7,
     #[doc = "Enables (1) or disables (0) the RC oscillator calibration"]
     rc_cal @ 3,
     #[doc = "Controls the Event 0 resolution as well as maximum timeout of the WOR module and maximum timeout under normal RX operation"]
-    wor_res @ 0..1,
+    wor_res @ 0..2,
 });
 
 register!(FREND1, 0b0101_0110, u8, {
     #[doc = "Adjusts front-end LNA PTAT current output"]
-    lna_current @ 6..7,
+    lna_current @ 6..8,
     #[doc = "Adjusts front-end PTAT outputs"]
-    lna2mix_current @ 4..5,
+    lna2mix_current @ 4..6,
     #[doc = "Adjusts current in RX LO buffer (LO input to mixer)"]
-    lodiv_buf_current_rx @ 2..3,
+    lodiv_buf_current_rx @ 2..4,
     #[doc = "Adjusts current in mixer"]
-    mix_current @ 0..1,
+    mix_current @ 0..2,
 });
 
 register!(FREND0, 0b0001_0000, u8, {
     #[doc = "Adjusts current TX LO buffer (input to PA)"]
-    lodiv_buf_current_tx @ 4..5,
+    lodiv_buf_current_tx @ 4..6,
     #[doc = "Selects PA power setting"]
-    pa_power @ 0..2,
+    pa_power @ 0..3,
 });
 
 register!(FSCAL3, 0b1010_1001, u8, {
     #[doc = "Frequency synthesizer calibration configuration"]
-    fscal3 @ 6..7,
+    fscal3 @ 6..8,
     #[doc = "Disable charge pump calibration stage when 0"]
-    chp_curr_cal_en @ 4..5,
+    chp_curr_cal_en @ 4..6,
     #[doc = "Frequency synthesizer calibration result register"]
-    fscal3_result @ 0..3,
+    fscal3_result @ 0..4,
 });
 
 register!(FSCAL2, 0b0000_1010, u8, {
     #[doc = "Choose high (1) / low (0) VCO"]
     vco_core_h_en @ 5,
     #[doc = "Frequency synthesizer calibration result register, VCO current calibration result and override value"]
-    fscal2 @ 0..4,
+    fscal2 @ 0..5,
 });
 
 register!(FSCAL1, 0b0010_0000, u8, {
     #[doc = "Frequency synthesizer calibration result register, capacitor array setting for VCO coarse tuning"]
-    fscal1 @ 0..5,
+    fscal1 @ 0..6,
 });
 
 register!(FSCAL0, 0b0000_1101, u8, {
     #[doc = "Frequency synthesizer calibration control"]
-    fscal0 @ 0..6,
+    fscal0 @ 0..7,
 });
 
 register!(RCCTRL1, 0b0100_0001, u8, {
     #[doc = "RC oscillator configuration"]
-    rcctrl1 @ 0..6,
+    rcctrl1 @ 0..7,
 });
 
 register!(RCCTRL0, 0b0000_0000, u8, {
     #[doc = "RC oscillator configuration."]
-    rcctrl0 @ 0..6,
+    rcctrl0 @ 0..7,
 
 });
 
 register!(FSTEST, 0b0101_1001, u8, {
     #[doc = "For test only. Do not write to this register."]
-    fstest @ 0..7,
+    fstest @ 0..8,
 });
 
 register!(PTEST, 0b0111_1111, u8, {
     #[doc = "Writing 0xBF to this register makes the on-chip temperature sensor available in the IDLE state"]
-    ptest @ 0..7,
+    ptest @ 0..8,
 });
 
 register!(AGCTEST, 0b0011_1111, u8, {
     #[doc = "For test only. Do not write to this register"]
-    agctest @ 0..7,
+    agctest @ 0..8,
 });
 
 register!(TEST2, 0b1000_1000, u8, {
     #[doc = "The value to use in this register is given by the SmartRF Studio software"]
-    test2 @ 0..7,
+    test2 @ 0..8,
 });
 
 register!(TEST1, 0b0011_0001, u8, {
     #[doc = "The value to use in this register is given by the SmartRF Studio software"]
-    test1 @ 0..7,
+    test1 @ 0..8,
 });
 
 register!(TEST0, 0b0000_1011, u8, {
     #[doc = "The value to use in this register is given by the SmartRF Studio software"]
-    test0_1 @ 2..7,
+    test0_1 @ 2..8,
     #[doc = "Enable VCO selection calibration stage when 1"]
     vco_sel_cal_en @ 1,
     #[doc = "The value to use in this register is given by the SmartRF Studio software"]

--- a/src/lowlevel/registers/status.rs
+++ b/src/lowlevel/registers/status.rs
@@ -49,44 +49,44 @@ impl From<Status> for crate::lowlevel::registers::Register {
 
 register!(PARTNUM, 0b0000_0000, u8, {
     #[doc = "Chip part number"]
-    partnum @ 0..7,
+    partnum @ 0..8,
 });
 
 register!(VERSION, 0b0001_0100, u8, {
     #[doc = "Chip version number"]
-    version @ 0..7,
+    version @ 0..8,
 });
 
 register!(FREQEST, 0b0000_0000, u8, {
     #[doc = "The estimated frequency offset (2's complement) of the carrier"]
-    freqoff_est @ 0..7,
+    freqoff_est @ 0..8,
 });
 
 register!(LQI, 0b0000_0000, u8, {
     #[doc = "The last CRC comparison matched."]
     crc_ok @ 7,
     #[doc = "The Link Quality Indicator estimates how easily a received signal can be demodulated"]
-    lqi @ 0..6,
+    lqi @ 0..7,
 });
 
 register!(RSSI, 0b0000_0000, u8, {
     #[doc = "Received signal strength indicator"]
-    rssi @ 0..7,
+    rssi @ 0..8,
 });
 
 register!(MARCSTATE, 0b0000_0000, u8, {
     #[doc = "Main Radio Control FSM State"]
-    marc_state @ 0..4,
+    marc_state @ 0..5,
 });
 
 register!(WORTIME1, 0b0000_0000, u8, {
     #[doc = "High byte of timer value in WOR module"]
-    time @ 0..7,
+    time @ 0..8,
 });
 
 register!(WORTIME0, 0b0000_0000, u8, {
     #[doc = "Low byte of timer value in WOR module"]
-    time @ 0..7,
+    time @ 0..8,
 });
 
 register!(PKTSTATUS, 0b0000_0000, u8, {
@@ -108,29 +108,29 @@ register!(PKTSTATUS, 0b0000_0000, u8, {
 
 register!(VCO_VC_DAC, 0b0000_0000, u8, {
     #[doc = "Status register for test only"]
-    vco_vc_dac @ 0..7,
+    vco_vc_dac @ 0..8,
 });
 
 register!(TXBYTES, 0b0000_0000, u8, {
     #[doc = "TX FIFO underflow"]
     txfifo_underflow @ 7,
     #[doc = "Number of bytes in TX FIFO"]
-    num_txbytes @ 0..6,
+    num_txbytes @ 0..7,
 });
 
 register!(RXBYTES, 0b0000_0000, u8, {
     #[doc = "RX FIFO overflow"]
     rxfifo_overflow @ 7,
     #[doc = "Number of bytes in RX FIFO"]
-    num_rxbytes @ 0..6,
+    num_rxbytes @ 0..7,
 });
 
 register!(RCCTRL1_STATUS, 0b0000_0000, u8, {
     #[doc = "Contains the value from the last run of the RC oscillator calibration routine"]
-    rcctrl1_status @ 0..6,
+    rcctrl1_status @ 0..7,
 });
 
 register!(RCCTRL0_STATUS, 0b0000_0000, u8, {
     #[doc = "Contains the value from the last run of the RC oscillator calibration routine"]
-    rcctrl0_status @ 0..6,
+    rcctrl0_status @ 0..7,
 });

--- a/src/lowlevel/registers/status_byte.rs
+++ b/src/lowlevel/registers/status_byte.rs
@@ -60,7 +60,7 @@ register!(STATUS_BYTE, 0b1000_0000, u8, {
     #[doc = "Stays high until power and crystal have stabilized. Should always be low when using the SPI interface."]
     chip_rdyn @ 7,
     #[doc = "Indicates the current main state machine mode"]
-    state @ 4..6,
+    state @ 4..7,
     #[doc = "The number of bytes available in the RX FIFO or free bytes in the TX FIFO"]
-    fifo_bytes_available @ 0..3,
+    fifo_bytes_available @ 0..4,
 });

--- a/src/lowlevel/traits.rs
+++ b/src/lowlevel/traits.rs
@@ -25,6 +25,18 @@ impl OffsetSize for Range<u8> {
     }
 }
 
+pub trait ToWider {
+    type Wider;
+    fn to_wider(self) -> Self::Wider;
+}
+
+impl ToWider for u8 {
+    type Wider = u16;
+    fn to_wider(self) -> Self::Wider {
+        self as u16
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct Mask;
 


### PR DESCRIPTION
- Fixed `register!` macro
- Added unit tests for `register!` macro
- Fixed bitfield size range for config, status, and status_byte registers
- Added 2 new functions:
    - `crc_autoflush_enable`
    - `append_status_enable`

**Note:**
The CC1101 datasheet shows bit ranges as inclusive on both sides (start and end), but Rust's [Range](https://doc.rust-lang.org/core/ops/struct.Range.html) is inclusive at the start and exclusive at the end.