### PR TITLE
Added functions to configure GDOx registers

### DIFF
--- a/src/lowlevel.rs
+++ b/src/lowlevel.rs
@@ -22,8 +22,7 @@ pub struct Cc1101<SPI> {
     pub status: Option<StatusByte>,
     pub length_field: bool,
     pub address_field: bool,
-    // gdo0: GDO0,
-    // gdo2: GDO2,
+    pub rx_status_fields: bool,
 }
 
 impl<SPI, SpiE> Cc1101<SPI>
@@ -36,6 +35,7 @@ where
             status: None,
             length_field: false,
             address_field: false,
+            rx_status_fields: true,
         };
         Ok(cc1101)
     }


### PR DESCRIPTION
- New functions:
    - set_gdo0_config
    - set_gdo1_config
    - set_gdo2_config
    - set_gdo0_active_state
    - set_gdo1_active_state
    - set_gdo2_active_state
    - temperature_sensor_enable
    - set_gdo_drive_strength
- Enhanced `read_data` function with optional rssi and lqi parameters
- Added TODO banner for future cleanup