### PR TITLE
idle the radio before changing any frequency registers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,12 @@ where
 
     /// Sets the carrier frequency (in Hertz).
     pub fn set_frequency(&mut self, hz: u64) -> Result<(), Error<SpiE>> {
+        // Before altering any frequency programming register we
+        // must stop the frequency synthesizer by going to Idle mode.
+        // See section 21 "Frequency Programming" of the data sheet
+        // (TI document SWRS061I).
+        self.set_radio_mode(RadioMode::Idle)?;
+
         let (freq0, freq1, freq2) = from_frequency(hz);
         self.0.write_register(Config::FREQ0, freq0)?;
         self.0.write_register(Config::FREQ1, freq1)?;


### PR DESCRIPTION
This is required per the datasheet.

From page 57 of the [data sheet](https://www.ti.com/lit/ds/swrs061i/swrs061i.pdf):
![image](https://github.com/user-attachments/assets/d5ef6043-6891-451e-a08e-b2d2aecff215)
