### PR TITLE
Fix frequency calculation

### DIFF
--- a/src/lowlevel/convert.rs
+++ b/src/lowlevel/convert.rs
@@ -7,7 +7,7 @@ pub const fn from_frequency(hz: u64) -> (u8, u8, u8) {
     let freq = hz * 1u64.rotate_left(16) / FXOSC;
     let freq0 = (freq & 0xff) as u8;
     let freq1 = ((freq >> 8) & 0xff) as u8;
-    let freq2 = ((freq >> 16) & 0xff) as u8;
+    let freq2 = ((freq >> 16) & 0x3f) as u8;
     (freq0, freq1, freq2)
 }
 

--- a/src/lowlevel/convert.rs
+++ b/src/lowlevel/convert.rs
@@ -65,7 +65,12 @@ mod tests {
 
     #[test]
     fn test_frequency() {
+        // (0x10a762 * 26_000_000 / 2**16) == 432_999_816.9
         assert_eq!(from_frequency(433_000_000), (0x62, 0xA7, 0x10));
+
+        // (0x10b071 * 26_000_000 / 2**16) == 433_919_830.3
+        assert_eq!(from_frequency(433_920_000), (0x71, 0xb0, 0x10));
+
         assert_eq!(from_frequency(868_000_000), (0x76, 0x62, 0x21));
         assert_eq!(from_frequency(902_000_000), (0x3B, 0xB1, 0x22));
         assert_eq!(from_frequency(918_000_000), (0xC4, 0x4E, 0x23));


### PR DESCRIPTION
This slightly improves the testing of `from_frequency()` and corrects a small bug in the calculation of FREQ2.  The top two bits of that register must be 0 per the [datasheet](https://www.ti.com/lit/ds/swrs061i/swrs061i.pdf): 
![image](https://github.com/user-attachments/assets/e6c09788-b1e9-483d-9fa3-361c83df4fda)
